### PR TITLE
Support for XML embedded in text

### DIFF
--- a/src/pycsspeechtts/pycsspeechtts.py
+++ b/src/pycsspeechtts/pycsspeechtts.py
@@ -73,7 +73,7 @@ class TTSTranslator(object):
             prosody.set('volume', volume)
             prosody.set('pitch', pitch)
             prosody.set('contour', contour)
-            prosody.text = text
+            prosody.append(ElementTree.fromstring(text))
 
         response = requests.post(
             endpoint, ElementTree.tostring(body), headers=headers)


### PR DESCRIPTION
This tries to address #14, although I want to hear your opinion on this approach. It is somewhat a "breaking" change in the sense that if invalid XML is passed in the text the code will now throw an exception, unlike before.

Other possible approaches would be:

* another boolean parameter denoting XML text or plain text (xml_text=True/False)
* fallback to plain (escaped) text in case of parsing errors

Maybe I'm just being excessively careful, but since this library is used by the Microsoft TTS Home Assistant component I would be careful introducing this change.