### PR TITLE
Add support for XML in text

### DIFF
--- a/src/pycsspeechtts/pycsspeechtts.py
+++ b/src/pycsspeechtts/pycsspeechtts.py
@@ -68,12 +68,12 @@ class TTSTranslator(object):
                 "X-Search-ClientID": "1ECFAE91408841A480F00935DC390960",
                 "User-Agent": "PYCSSpeechTTS"
                 }
-            prosody = ElementTree.SubElement(voice, 'prosody')
+            voice.append(ElementTree.XML('<prosody>'+text+'</prosody>'))
+            prosody = voice.find('prosody')
             prosody.set('rate', rate)
             prosody.set('volume', volume)
             prosody.set('pitch', pitch)
             prosody.set('contour', contour)
-            prosody.text = text
 
         response = requests.post(
             endpoint, ElementTree.tostring(body), headers=headers)

--- a/src/pycsspeechtts/test.py
+++ b/src/pycsspeechtts/test.py
@@ -2,11 +2,14 @@ from pycsspeechtts import TTSTranslator
 useCustom = True
 api_key = "YOUR_API_KEY"
 custom_endpoint = "custom_endpoint"
+region = "westus"
 
 if not useCustom:
-    t = TTSTranslator(api_key, region="westus")
+    t = TTSTranslator(api_key, region=region)
     # Speaking with default language of english US and default Female voice
     data = t.speak(text='This is a test')
+    # Adding a pause to test XML support
+    data = t.speak(text='This is a test with a <break time="2s" />long pause')
     # Change speed with -50%
     data = t.speak(text="This is a test", rate="-50%")
     # Change pitch to high
@@ -22,7 +25,7 @@ if not useCustom:
                 contour="(0%,+0%) (100%,+100%)")
 else:
     # Test custom voice
-    t = TTSTranslator(api_key, region="westus", isCustom=True, customEndpoint=custom_endpoint)
+    t = TTSTranslator(api_key, region=region, isCustom=True, customEndpoint=custom_endpoint)
     data = t.speak(language='en-gb',gender='Male',voiceType="ArchieNeural",text="This is a test for custom voice")
 
 if data == None:


### PR DESCRIPTION
Please consider the following PR. It is an extension of pull request #15 and addresses issue #14 .

The current PR allows for using XML tags inside the text, whilst also remaining backward compatible with a regular, non-xml formatted string.

For example, all of these work:

- `This is a regular, backwards compatible sentence`
- `This is a sentence with a <break time="2s" /> long pause`
- `<p>Sentence 1 in paragraph 1.</p><p>Sentence 2 in paragraph 2</p>`
- `Test sentence for <prosody pitch="high">double prosody elements</prosody>`
