### PR TITLE
Add namespaces for Microsoft Style tags

### DIFF
--- a/src/pycsspeechtts/pycsspeechtts.py
+++ b/src/pycsspeechtts/pycsspeechtts.py
@@ -45,6 +45,7 @@ class TTSTranslator(object):
         voice = ElementTree.SubElement(body, 'voice')
         voice.set('{http://www.w3.org/XML/1998/namespace}lang', language)
         voice.set('{http://www.w3.org/XML/1998/namespace}gender', gender)
+        voice.set('{http://www.w3.org/XML/1998/namespace}mstts', 'http://www.w3.org/2001/mstts')
         voice.set(
             'name', 'Microsoft Server Speech Text to Speech Voice ('+name_lang(language)+', '+voiceType+')')
 

--- a/src/pycsspeechtts/pycsspeechtts.py
+++ b/src/pycsspeechtts/pycsspeechtts.py
@@ -41,11 +41,12 @@ class TTSTranslator(object):
         
         body = ElementTree.Element('speak', version='1.0')
         body.set('{http://www.w3.org/XML/1998/namespace}lang', language)
+        body.set('xmlns','http://www.w3.org/2001/10/synthesis')
+        body.set('xmlns:mstts', 'http://www.w3.org/2001/mstts')
 
         voice = ElementTree.SubElement(body, 'voice')
         voice.set('{http://www.w3.org/XML/1998/namespace}lang', language)
         voice.set('{http://www.w3.org/XML/1998/namespace}gender', gender)
-        voice.set('{http://www.w3.org/XML/1998/namespace}mstts', 'http://www.w3.org/2001/mstts')
         voice.set(
             'name', 'Microsoft Server Speech Text to Speech Voice ('+name_lang(language)+', '+voiceType+')')
 


### PR DESCRIPTION
This pull request will add a couple of namespace tags. This will allow for proper XML parsing when passing text such as:

```
<mstts:express-as xmlns:mstts="http://www.w3.org/2001/mstts" style="cheerful">This is my cheerful voice!</mstts:express-as>
```
The details of those tags are here: https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup#style

Note that it is also required to pass the `xmlns:mstts="http://www.w3.org/2001/mstts"` portion in the text - I couldn't find a way to make it work without that. If there is a way to omit that without causing errors, it would make using the style options a lot easier.

This closes https://github.com/jeroenterheerdt/pycsspeechtts/issues/19. Additionally, if you could tag a release after testing/accepting this change, that would be appreciated as then I can do a PR to have Home Assistant utilize the new features :)